### PR TITLE
docs: add README and org-wide security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# .github
+
+Organization-wide GitHub configurations for [He4rt Developers](https://heartdevs.com).
+
+Files placed in this repository act as **organization-wide defaults**. Any repository under the `he4rt` organization that does not define its own version of these files will inherit them from here.
+
+## Community
+
+- [Discord](https://discord.gg/he4rt)
+- [Twitter](https://twitter.com/He4rtDevs)
+- [Instagram](https://instagram.com/heartdevs)
+- [LinkedIn](https://www.linkedin.com/company/he4rt/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+**PLEASE DON'T DISCLOSE SECURITY-RELATED ISSUES PUBLICLY, [SEE BELOW](#reporting-a-vulnerability).**
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately:
+
+- **GitHub Private Vulnerability Reporting** (preferred) — go to the repository's **Security** tab and click **"Report a vulnerability"**. This creates a private advisory visible only to maintainers and provides a structured workflow for triage, fix coordination, and CVE assignment.
+
+All security vulnerabilities will be promptly addressed.
+
+## Scope
+
+This policy applies to all repositories under the [he4rt](https://github.com/he4rt) GitHub organization, unless a repository defines its own `SECURITY.md`.


### PR DESCRIPTION
## Summary
- Add repository README explaining the purpose of the `.github` repo and linking to community channels
- Add org-wide `SECURITY.md` directing vulnerability reporters to GitHub Private Vulnerability Reporting