### PR TITLE
docs: add org-wide code of conduct, contributing guide, and license

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Code of Conduct
+
+## Our Commitment
+
+He4rt Developers was built on the belief that everyone deserves access to quality tech education regardless of their background. As a community dedicated to helping beginners become professionals through open source projects, mentoring, and collaboration, we are committed to providing a welcoming, safe, and harassment-free environment for all participants.
+
+We pledge to act and interact in ways that contribute to an open, diverse, and inclusive community — from the community, for the community.
+
+## Expected Behavior
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+- Being patient with beginners — we are a learning community
+- Giving credit where credit is due
+
+## Unacceptable Behavior
+
+- Racism, sexism, homophobia, transphobia, xenophobia, or any form of discrimination
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information (doxxing) without their explicit consent
+- Sharing offensive, obscene, or violent material
+- Distributing malicious links, pirated content, or engaging in illegal activities
+- Any other conduct that could reasonably be considered inappropriate in a professional or educational setting
+
+## Scope
+
+This Code of Conduct applies to all repositories under the [he4rt](https://github.com/he4rt) GitHub organization, unless a repository defines its own `CODE_OF_CONDUCT.md`. It applies within all project spaces — including issues, pull requests, discussions, commits, and wikis — as well as when an individual is representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported through the following channels:
+
+- **GitHub** — open a report via the repository's **Security** tab or contact the maintainers directly through a private issue
+
+All reports will be reviewed and investigated promptly and confidentially. Maintainers are obligated to respect the privacy of the reporter.
+
+### Enforcement Actions
+
+Depending on the nature and severity of the violation, maintainers may take the following actions:
+
+1. **Warning** — a private notice clarifying the violation and expected behavior going forward
+2. **Temporary ban** — removal from project spaces for a defined period
+3. **Permanent ban** — indefinite removal from all community project spaces
+
+Maintainers who do not follow or enforce this Code of Conduct in good faith may face repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, with modifications to reflect He4rt Developers' mission and values.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to He4rt Developers
+
+Thank you for your interest in contributing! Whether you're fixing a typo, reporting a bug, or building a new feature, your help is welcome here. No contribution is too small, and we value contributors of all experience levels.
+
+This guide applies to all repositories under the [he4rt](https://github.com/he4rt) GitHub organization unless a repository provides its own `CONTRIBUTING.md` with project-specific instructions.
+
+## Getting Started
+
+### Prerequisites
+
+- A [GitHub](https://github.com) account
+- [Git](https://git-scm.com/) installed on your machine
+- Familiarity with basic Git operations (or the willingness to learn!)
+
+### Finding Something to Work On
+
+- Look for issues labeled [`good first issue`](https://github.com/search?q=org%3Ahe4rt+label%3A%22good+first+issue%22+state%3Aopen&type=issues) or [`help wanted`](https://github.com/search?q=org%3Ahe4rt+label%3A%22help+wanted%22+state%3Aopen&type=issues)
+- Check the repository's README for project-specific setup and open tasks
+- Not sure where to start? Ask in our [Discord](https://discord.gg/he4rt) — we are happy to help
+
+## How to Contribute
+
+### Fork and Pull Request Workflow
+
+1. **Fork** the repository by clicking the "Fork" button on the top right of the repo page
+
+2. **Clone** your fork locally:
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/REPO-NAME.git
+   cd REPO-NAME
+   ```
+
+3. **Create a branch** for your changes:
+   ```bash
+   git checkout -b my-new-feature
+   ```
+
+4. **Make your changes** — write code, fix bugs, improve docs
+
+5. **Stage and commit** your work:
+   ```bash
+   git add .
+   git commit -m "Add brief description of your change"
+   ```
+
+6. **Push** your branch to your fork:
+   ```bash
+   git push origin my-new-feature
+   ```
+
+7. **Open a Pull Request** — go to the original repository on GitHub and click "Compare & pull request". Provide a clear title and description of what you changed and why.
+
+### Commit Messages
+
+- Use the imperative mood: "Add feature" not "Added feature"
+- Keep the subject line under 72 characters
+- Reference related issues when applicable (e.g., `Fix #42`)
+
+### Pull Request Guidelines
+
+- Provide a clear title and description
+- Reference any related issues
+- Keep changes focused — one pull request per feature or fix
+- Make sure existing tests pass (if applicable)
+- Be responsive to review feedback
+
+## Reporting Bugs
+
+Before opening a new issue, check if the bug has already been reported. If not, create a new issue including:
+
+- A clear, descriptive title
+- Steps to reproduce the behavior
+- Expected behavior vs. actual behavior
+- Environment details (OS, browser, language version, etc.)
+- Screenshots or logs, if relevant
+
+## Suggesting Features
+
+We welcome ideas that improve our projects. Open an issue describing:
+
+- The problem you want to solve
+- Your proposed solution
+- Any alternatives you considered
+
+## Code Standards
+
+Each repository may define its own code standards and tooling. When in doubt:
+
+- Follow the existing code style in the repository
+- Write clean, readable code
+- Include tests when the project has a test suite
+- Run any linters or formatters the project provides before submitting
+
+## Community
+
+- Join our [Discord](https://discord.gg/he4rt) for questions, discussions, and mentoring
+- Follow us on [Twitter](https://twitter.com/He4rtDevs) for updates
+
+## Code of Conduct
+
+All contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md). Please read it before participating.
+
+## Security
+
+To report security vulnerabilities, **do not open a public issue**. Please see our [Security Policy](SECURITY.md) for instructions on private reporting.
+
+## License
+
+By contributing to any He4rt Developers project, you agree that your contributions will be licensed under the same license as the project you are contributing to.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-present He4rt Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- **CODE_OF_CONDUCT.md** — Adapted from Contributor Covenant, customized for He4rt's educational mission. Includes explicit zero-tolerance for discrimination, patience with beginners as an expected behavior, and GitHub-only enforcement.
- **CONTRIBUTING.md** — Beginner-friendly fork+PR guide with step-by-step git commands, `good first issue` pointers, and cross-references to the Code of Conduct and Security Policy.
- **LICENSE** — MIT License, copyright He4rt Developers 2019-present.

All three files serve as organization-wide defaults (inherited by any he4rt repo that doesn't define its own version). They follow the same professional tone and scope pattern as the existing `SECURITY.md`.