### PR TITLE
ci: auto-merge Dependabot patch & minor updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on:
+  # zizmor: ignore[dangerous-triggers] — only checks out base branch to load the composite action, no untrusted code runs
+  pull_request_target:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  automerge:
+    name: Auto-merge Dependabot patch & minor
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    timeout-minutes: 5
+    permissions:
+      contents: write # squash-merge the PR
+      pull-requests: write # approve the PR
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./actions/dependabot-automerge

--- a/actions/dependabot-automerge/README.md
+++ b/actions/dependabot-automerge/README.md
@@ -1,0 +1,64 @@
+# dependabot-automerge
+
+Composite action that approves and squash-merges **Dependabot** pull requests
+for **`github-actions`** dependencies when the bump is a **patch** or **minor**
+update. Major bumps and every other ecosystem are left open for manual review.
+
+## What it does
+
+| Dependabot PR | Result |
+| --- | --- |
+| `github-actions` · patch (`7.0.0 → 7.0.1`) | ✅ approved, squash-merged |
+| `github-actions` · minor (`7.0.0 → 7.1.0`) | ✅ approved, squash-merged |
+| `github-actions` · major (`7.x → 8.0.0`) | ❌ left open |
+| any other ecosystem (npm, composer, …) | ❌ left open |
+| non-Dependabot PR | ❌ ignored |
+
+## Usage in another repository
+
+Add a workflow that runs on Dependabot PRs and calls this action. No checkout is
+needed — the action is pulled from `he4rt/.github`.
+
+```yaml
+# .github/workflows/dependabot-automerge.yml
+name: Dependabot auto-merge
+
+on:
+  # zizmor: ignore[dangerous-triggers] — no PR code is executed, only metadata + API calls
+  pull_request_target:
+    branches: [main] # match your default branch
+
+permissions: {}
+
+jobs:
+  automerge:
+    name: Auto-merge Dependabot patch & minor
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    timeout-minutes: 5
+    permissions:
+      contents: write # squash-merge the PR
+      pull-requests: write # approve the PR
+    steps:
+      - uses: he4rt/.github/actions/dependabot-automerge@main # pin to a commit SHA in production
+```
+
+> `pull_request_target` is required: Dependabot PRs get a read-only token under
+> `pull_request` and cannot merge. This workflow does not check out PR code, so
+> the trigger is safe.
+
+## Requirements
+
+- **Settings → Actions → General → "Allow GitHub Actions to create and approve
+  pull requests"** must be enabled for the approval step.
+- The merge uses plain `gh pr merge --squash`, which merges immediately and only
+  needs `contents: write`. If the target repo has **branch protection with
+  required checks**, switch the action's merge command to `gh pr merge --auto`
+  so it waits for green checks instead.
+
+## How it works
+
+1. [`dependabot/fetch-metadata`](https://github.com/dependabot/fetch-metadata)
+   reads `package-ecosystem` and `update-type`.
+2. If `package-ecosystem == github_actions` and the update is patch or minor,
+   the PR is approved and squash-merged.

--- a/actions/dependabot-automerge/action.yml
+++ b/actions/dependabot-automerge/action.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+description: Approve and squash-merge Dependabot patch & minor github-actions updates
+
+runs:
+  using: composite
+  steps:
+    - name: Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+      with:
+        github-token: ${{ github.token }}
+
+    - name: Approve and squash-merge patch & minor github-actions updates
+      if: ${{ steps.metadata.outputs.package-ecosystem == 'github_actions' && contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      run: |
+        gh pr review "$PR_URL" --approve --body "Auto-approved Dependabot patch/minor update"
+        gh pr merge "$PR_URL" --squash


### PR DESCRIPTION
## Summary
- Add `actions/dependabot-automerge` composite action: reads Dependabot metadata, then approves and squash-merges the PR when the update is a `github_actions` **patch** or **minor** bump. Majors, other ecosystems, and non-Dependabot PRs are left open.
- Add a thin `pull_request_target` workflow that guards on `dependabot[bot]` and loads the action via `uses: ./actions/dependabot-automerge` — mirroring the existing `auto-assign` split so the action is reusable across he4rt repos.
- Add a README documenting behavior, the drop-in caller workflow for other repos, and the one org setting required.

## Why
Dependabot's `github-actions` patch/minor bumps carry no design decision but still need a manual merge. This clears that toil while keeping majors human-reviewed.

## Notes
- Uses plain `gh pr merge --squash` (immediate; only needs `contents: write`). `--auto` can't be enabled without required checks; switch to it if branch protection is added later.
- `fetch-metadata` pinned to a full commit SHA (v3.1.0); least-privilege permissions.

## Test plan
- [x] On the next Dependabot `github-actions` PR, confirm the run detects `package-ecosystem=github_actions` + the update type.
- [x] Patch/minor PR is approved and squash-merged automatically.
- [x] A major bump (or other ecosystem) leaves the step skipped and the PR open.